### PR TITLE
feat: manifest v3 + base support for chat settings

### DIFF
--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -4,14 +4,5 @@
          "id": "twitchantiban@timofey",
          "strict_min_version": "101.0"
       }
-   },
-   "permissions": [
-      "storage",
-      "*://*.amazonaws.com/*",
-      "*://*.betterttv.net/*",
-      "*://*.7tv.io/*",
-      "*://*.twitch.tv/*",
-      "*://*.ttvnw.net/*"
-   ],
-   "manifest_version": 2
+   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,6 +32,13 @@
   "permissions": [
     "storage"
   ],
+  "host_permissions": [
+    "*://*.amazonaws.com/*",
+    "*://*.betterttv.net/*",
+    "*://*.7tv.io/*",
+    "*://*.twitch.tv/*",
+    "*://*.ttvnw.net/*"
+  ],
   "description": "Automatically opens a proxy stream & chat if you are banned in a channel.",
   "icons": {
     "128": "images/icon128.png",
@@ -40,5 +47,5 @@
   },
   "manifest_version": 3,
   "name": "Twitch Anti-Ban",
-  "version": "3.3"
+  "version": "4.0"
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,7 @@
 const twitchColors = ["#FF0000", "#0000FF", "#008000", "#B22222", "#E05B5B", "#FF7F50", "#9ACD32", "#FF4500", "#2E8B57", "#DAA520", "#D2691E", "#5F9EA0", "#1E90FF", "#FF69B4", "#8A2BE2", "#00FF7F"];
 
+let browser = browser || chrome;
+
 async function fetchJson(url, method = "GET", headers = {}, body = null) {
     try {
         const response = await fetch(url, {
@@ -55,21 +57,13 @@ async function getTwitchBadges(userId) {
 
 async function getFromStorage(key) {
     return new Promise((resolve) => {
-        if (typeof browser !== 'undefined') {
-            browser.storage.local.get([key]).then((result) => resolve(result[key]));
-        } else {
-            chrome.storage.local.get([key], (result) => resolve(result[key]));
-        }
+        browser.storage.local.get([key]).then((result) => resolve(result[key]));
     });
 }
 
 async function storeToStorage(key, value) {
     return new Promise((resolve) => {
-        if (typeof browser !== 'undefined') {
-            browser.storage.local.set({[key]: value}).then(resolve);
-        } else {
-            chrome.storage.local.set({[key]: value}, resolve);
-        }
+        browser.storage.local.set({ [key]: value }).then(resolve);
     });
 }
 
@@ -96,7 +90,7 @@ function parseIRCMessage(message) {
     if (source.startsWith(':')) {
         const sourceString = source.substring(1);
         const [nickname, user, host] = sourceString.split(/[!@]/);
-        parsedMessage.source = {nickname, user, host};
+        parsedMessage.source = { nickname, user, host };
     }
 
     parsedMessage.command = command;


### PR DESCRIPTION
Extension migrated to the devil Manifest V3. Tested on last version of Edge and Firefox ; should work with the Chromium-world. Works on Waterfox, dunno about Pale Moon or LibreWolf.

For accessibility purposes, the font size setting is now respected. Timestamp toggling is also honored.

Note: feature is not reactive. Settings updated => a refresh is needed. Also, I tried to implement a service worker for an isolated observer, but since we do not really need it, I threw it. Manifest v2/v3 incompatibilities are boring to handle.