### PR TITLE
fix(proxy-chat): handle undefined emote properties to prevent crashes

### DIFF
--- a/src/proxy-chat.js
+++ b/src/proxy-chat.js
@@ -53,19 +53,31 @@ ProxyChat = {
         }
 
         for (const endpoint of ['emote-sets/global', `users/twitch/${ProxyChat.channelId}`]) {
-            const stvEmotes = await fetchJson(`https://7tv.io/v3/${endpoint}`);
-            const emotes = stvEmotes?.emote_set?.emotes ?? stvEmotes?.emotes ?? [];
-            emotes?.forEach(emote => {
-                const bestQualityEmote = emote.data.host.files.pop();
-                const lowestQualityEmote = emote.data.host.files.shift();
+    const stvEmotes = await fetchJson(`https://7tv.io/v3/${endpoint}`);
+    const emotes = stvEmotes?.emote_set?.emotes ?? stvEmotes?.emotes ?? [];
+
+    emotes.forEach(emote => {
+        // Check if emote and required properties exist before accessing them
+        if (emote?.data?.host?.files && emote?.name) {
+            const bestQualityEmote = emote.data.host.files.pop();
+            const lowestQualityEmote = emote.data.host.files.shift();
+            
+            // Ensure the required properties are valid
+            if (bestQualityEmote?.name && lowestQualityEmote?.width && lowestQualityEmote?.height) {
                 ProxyChat.thirdPartyEmotes[emote.name] = {
                     id: emote.id,
                     src: `https:${emote.data.host.url}/${bestQualityEmote.name}`,
                     width: `${lowestQualityEmote.width / 10}rem`,
                     height: `${lowestQualityEmote.height / 10}rem`
                 };
-            });
+            } else {
+                console.error("Invalid emote file properties:", emote);
+            }
+        } else {
+            console.error("Invalid emote data:", emote);
         }
+    });
+}
 
         // store emotes priority by its length
         ProxyChat.thirdPartyEmoteCodesByPriority = Object.keys(ProxyChat.thirdPartyEmotes);


### PR DESCRIPTION
Got `proxy-chat.js:63 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'name')` today. It broke the script, so I came up with a potential fix.


Resolved a TypeError occurring when the emote object from the 7TV API contains undefined or unexpected properties. 

- Added checks to ensure `emote` and its nested properties (`name`, `data.host.files`) are defined before accessing them.
- Implemented fallback logic to avoid crashes caused by incomplete emote data.
- Included error logging for invalid or malformed emote objects to aid debugging.